### PR TITLE
Revert "Upgrade pip because upgrade pip."

### DIFF
--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -11,7 +11,6 @@ RUN mkdir -p /srv/venv && chown -R jovyan:jovyan /srv/venv
 USER jovyan
 
 RUN python3 -m venv /srv/venv
-RUN /srv/venv/bin/pip3 install --upgrade pip
 RUN /srv/venv/bin/pip3 install --no-cache-dir notebook ipykernel jupyterhub
 
 ENV PATH /srv/venv/bin:$PATH


### PR DESCRIPTION
Reverts jupyterhub/helm-chart#15

From https://github.com/jupyterhub/helm-chart/pull/15#issuecomment-300548967:

> 1. This makes the image being built non-deterministic. It'll get a different version of pip each time we build it.
> 2. It adds another axes to the package management set of axes (ubuntu version, python version, pip version). Ideally I want ubuntu version to imply both python and pip version, so we can just say 'ubuntu 17.04' rather than 'ubuntu 17.04 and pip 9.0.1', since the latter implies variants we might have to also support ('ubuntu 17.04 and pip 8.x', 'ubuntu 17.04 and pip 10')
> 3. Ubuntu 17.04 actually has pip 9.0, so should solve our problems. Upgrading the FROM to 17.04 is welcome, and I might do that soon myself :)

I'm a fan of using pip to upgrade itself when we're running locally and upgrading the base OS is hard, but inside Docker images I'm a fan of just updating the base image instead. Inside Docker images, we have full control over the environment - and so several best practices for local usage don't apply anymore. Instead, we should optimize for determinism, simplicity and clarity.