### PR TITLE
use configurable-http-proxy by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ IMAGE_PREFIX=jupyterhub/k8s
 PUSH_IMAGES=no
 
 images: build-images push-images
-build-images: build-image/hub build-image/proxy build-image/singleuser-sample build-image/binderhub
-push-images: push-image/hub push-image/proxy push-image/singleuser-sample push-image/binderhub
+build-images: build-image/hub build-image/singleuser-sample build-image/binderhub
+push-images: push-image/hub push-image/singleuser-sample push-image/binderhub
 
 build-image/%:
 	cd images/$(@F) && \

--- a/images/proxy/Dockerfile
+++ b/images/proxy/Dockerfile
@@ -1,6 +1,0 @@
-FROM jupyterhub/configurable-http-proxy:2.0.1
-
-CMD configurable-http-proxy --ip 0.0.0.0 --port 8000 \
-    --api-ip 0.0.0.0 --api-port 8001 \
-    --default-target http://${HUB_SERVICE_HOST}:${HUB_SERVICE_PORT} \
-    --error-target http://${HUB_SERVICE_HOST}:${HUB_SERVICE_PORT}

--- a/images/proxy/Dockerfile
+++ b/images/proxy/Dockerfile
@@ -1,21 +1,6 @@
-FROM ubuntu:17.04
+FROM jupyterhub/configurable-http-proxy:2.0.1
 
-RUN apt-get update
-
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends \
-      ca-certificates \
-      nginx-extras \
-      git \
-      python3-pip \
-      python3-setuptools \
-      curl \
-      lua-cjson && \
-    apt-get clean && apt-get purge
-
-RUN pip3 install jinja2 traitlets
-RUN pip3 install git+https://github.com/yuvipanda/jupyterhub-nginx-chp.git@4bd293e
-
-EXPOSE 8000
-
-CMD /usr/local/bin/nchp --ip 0.0.0.0 --port 8000 --api-ip 0.0.0.0 --api-port 8001  --default-target http://${HUB_SERVICE_HOST}:${HUB_SERVICE_PORT} 
+CMD configurable-http-proxy --ip 0.0.0.0 --port 8000 \
+    --api-ip 0.0.0.0 --api-port 8001 \
+    --default-target http://${HUB_SERVICE_HOST}:${HUB_SERVICE_PORT} \
+    --error-target http://${HUB_SERVICE_HOST}:${HUB_SERVICE_PORT}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
       - name: proxy-container
         image: {{ .Values.proxy.image.name }}:{{ .Values.proxy.image.tag }}
+        command: {{ toJson .Values.proxy.cmd }}
         resources:
 {{ toYaml .Values.proxy.resources | indent 12 }}
         env:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -35,8 +35,16 @@ proxy:
   service:
     type: ClusterIP
   image:
-    name: jupyterhub/k8s-proxy
-    tag: v0.3.1
+    name: jupyterhub/configurable-http-proxy
+    tag: 2.0.1
+  cmd: 
+    - configurable-http-proxy
+    - --ip=0.0.0.0
+    - --port=8000
+    - --api-ip=0.0.0.0
+    - --api-port=8001
+    - --default-target=http://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)
+    - --error-target=http://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)
   resources:
     requests:
       cpu: 0.2


### PR DESCRIPTION
simplifies proxy image, makes behavior more consistent with defaults

With JupyterHub 0.8, we can hopefully switch to kubernetes ingress

@yuvipanda does switching the default to CHP here make it difficult for you to use nginx-chp in your deployments as needed? Do we need to solve #1 for that?