### PR TITLE
base singleuser-sample on docker-stacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 VERSION=$(shell git rev-parse --short HEAD)
 IMAGE_PREFIX=jupyterhub/k8s
+JUPYTERHUB_VERSION ?= 0.7.2
 PUSH_IMAGES=no
 
 images: build-images push-images
@@ -8,7 +9,7 @@ push-images: push-image/hub push-image/singleuser-sample push-image/binderhub
 
 build-image/%:
 	cd images/$(@F) && \
-	docker build -t $(IMAGE_PREFIX)-$(@F):v$(VERSION) .
+	docker build -t $(IMAGE_PREFIX)-$(@F):v$(VERSION) --build-arg JUPYTERHUB_VERSION=$(JUPYTERHUB_VERSION) .
 
 push-image/%:
 	docker push $(IMAGE_PREFIX)-$(@F):v$(VERSION)

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -15,9 +15,10 @@ RUN apt-get update && \
       python3-pip && \
      apt-get purge && apt-get clean
 
+ARG JUPYTERHUB_VERSION=0.7.2
 
 RUN pip3 install --no-cache-dir \
-         jupyterhub==0.7.2 \
+         jupyterhub==$JUPYTERHUB_VERSION \
          oauthenticator==0.5.1 \
          statsd==3.2.1 \
          jupyterhub-dummyauthenticator==0.3.1 \
@@ -34,4 +35,4 @@ WORKDIR /srv/jupyterhub
 # JupyterHub API port
 EXPOSE 8081
 
-CMD jupyterhub --config /srv/jupyterhub_config.py --no-ssl
+CMD jupyterhub --config /srv/jupyterhub_config.py

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -2,8 +2,14 @@ FROM jupyter/base-notebook:cfddc5a3163f
 
 # conda/pip/apt install additional packages here, if desired.
 
+# pin jupyterhub to match the Hub verion
+# set via --build-arg in Makefile
+ARG JUPYTERHUB_VERSION=0.7.2
+RUN pip install jupyterhub==$JUPYTERHUB_VERSION
+
 # Set working directory to $HOME, needed for persistence
 # docker-stacks default is ~/work, which won't exist if we mount $HOME as a volume
+# FIXME: this becomes obsolete after https://github.com/jupyter/docker-stacks/pull/388
 WORKDIR $HOME
 
 # select single-user launch command by default for JupyterHub:

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -1,29 +1,10 @@
-FROM ubuntu:17.04
+FROM jupyter/base-notebook:cfddc5a3163f
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends python3 python3-venv && \
-    apt-get purge && apt-get clean
+# conda/pip/apt install additional packages here, if desired.
 
-RUN adduser --disabled-password --gecos "Default Jupyter user" jovyan
+# Set working directory to $HOME, needed for persistence
+# docker-stacks default is ~/work, which won't exist if we mount $HOME as a volume
+WORKDIR $HOME
 
-RUN mkdir -p /srv/venv && chown -R jovyan:jovyan /srv/venv
-
-USER jovyan
-
-RUN python3 -m venv /srv/venv
-RUN /srv/venv/bin/pip3 install --no-cache-dir notebook ipykernel jupyterhub
-
-ENV PATH /srv/venv/bin:$PATH
-
-WORKDIR /home/jovyan
-
-EXPOSE 8888
-
-CMD jupyterhub-singleuser \
-  --port=8888 \
-  --ip=0.0.0.0 \
-  --user="$JPY_USER" \
-  --cookie-name=$JPY_COOKIE_NAME \
-  --base-url=$JPY_BASE_URL \
-  --hub-prefix=$JPY_HUB_PREFIX \
-  --hub-api-url=$JPY_HUB_API_URL
+# select single-user launch command by default for JupyterHub:
+CMD /usr/local/bin/start-singleuser.sh


### PR DESCRIPTION
Use smallest base-notebook with placeholder for installation of packages.

The main change needed is to set WORKDIR to $HOME instead of the default $HOME/work in order for volume persistence to work

I'm *pretty sure* this works, but I haven't been able to do a full deployment to confirm. We can investigate further next week.