### PR TITLE
Githubauth

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -139,6 +139,11 @@ if auth_type == 'google':
     c.GoogleOAuthenticator.hosted_domain = get_config('auth.google.hosted-domain')
     c.GoogleOAuthenticator.login_service = get_config('auth.google.login-service')
     email_domain = get_config('auth.google.hosted-domain')
+elif auth_type == 'github':
+    c.JupyterHub.authenticator_class = 'oauthenticator.GitHubOAuthenticator'
+    c.GitHubOAuthenticator.oauth_callback_url = get_config('auth.github.callback-url')
+    c.GitHubOAuthenticator.client_id = get_config('auth.github.client-id')
+    c.GitHubOAuthenticator.client_secret = get_config('auth.github.client-secret')
 elif auth_type == 'hmac':
     c.JupyterHub.authenticator_class = 'hmacauthenticator.HMACAuthenticator'
     c.HMACAuthenticator.secret_key = bytes.fromhex(get_config('auth.hmac.secret-key'))

--- a/jupyterhub/templates/hub.yaml
+++ b/jupyterhub/templates/hub.yaml
@@ -66,6 +66,12 @@ data:
   auth.google.login-service: {{.Values.auth.google.loginService | quote}}
   auth.google.callback-url: {{.Values.auth.google.callbackUrl}}
   {{- end }}
+  {{ if eq .Values.auth.type "github" -}}
+  auth.github.client-id: {{.Values.auth.github.clientId | quote}}
+  auth.github.client-secret: {{.Values.auth.github.clientSecret | quote}}
+  auth.github.callback-url: {{.Values.auth.github.callbackUrl}}
+  {{- end }}
+
   {{ if eq .Values.auth.type "dummy" -}}
   {{ if .Values.auth.dummy.password -}}
   auth.dummy.password: {{ .Values.auth.dummy.password | quote }}

--- a/jupyterhub/templates/hub.yaml
+++ b/jupyterhub/templates/hub.yaml
@@ -69,7 +69,7 @@ data:
   {{ if eq .Values.auth.type "github" -}}
   auth.github.client-id: {{.Values.auth.github.clientId | quote}}
   auth.github.client-secret: {{.Values.auth.github.clientSecret | quote}}
-  auth.github.callback-url: {{.Values.auth.github.callbackUrl}}
+  auth.github.callback-url: {{.Values.auth.github.callbackUrl | quote}}
   {{- end }}
 
   {{ if eq .Values.auth.type "dummy" -}}


### PR DESCRIPTION
This updates the Jupyterhub image in order to enable GitHub authorization.

Should close https://github.com/jupyterhub/helm-chart/issues/30 once the standard images are rebuilt. 