### PR TITLE
Allow setting hub related variables in config map.

### DIFF
--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -46,6 +46,9 @@ data:
   hub.extra-config.py: |
 {{ .Values.hub.extraConfig | indent 4 }}
   {{- end }}
+  {{ if .Values.hub.extraConfigVars -}}
+  hub.extra-vars: {{ toJson .Values.hub.extraConfigVars | quote }}
+  {{- end }}
   {{ if .Values.singleuser.cmd -}}
   singleuser.cmd: {{ .Values.singleuser.cmd | quote }}
   {{- end }}


### PR DESCRIPTION
Here's what I have in my config.yaml:

```
hub:
  ...
  extraConfigVars:
    secret_key: "hello_world"
    timeout_value: 240
```

And in the pod:
```bash
$ kubectl exec hub-deployment-2390299585-wgz9k -- cat /etc/jupyterhub/config/hub.extra-vars
{"secret_key":"hello_world","timeout_value":240}
```