### PR TITLE
Allow for custom imagePullPolicy for hub.

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.hub.resources | indent 12}}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.hub.imagePullPolicy }}
         env:
         # Put this here directly so hub will restart when we
         # change this

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -29,6 +29,7 @@ spec:
               secretKeyRef:
                 name: hub-secret
                 key: proxy.token
+        imagePullPolicy: {{ .Values.proxy.imagePullPolicy }}
         ports:
           - containerPort: 8000
             name: proxy-public

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -49,6 +49,7 @@ proxy:
       cpu: 0.2
       memory: 512Mi
   labels: null
+  imagePullPolicy: IfNotPresent
 
 ingress:
   enabled: false

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -23,6 +23,7 @@ hub:
     requests:
       cpu: 0.2
       memory: 512Mi
+  imagePullPolicy: IfNotPresent
 
 proxy:
   secretToken: 'generate with openssl rand -hex 64'


### PR DESCRIPTION
This makes it easier to iterate on a debug image which has the same tag.

When debugging, in config.yaml, set:

```bash
hub:
  imagePullPolicy: Always
```

After that, change image code and re-upload Docker image. There's no need
to edit config.yaml after each reupload.

When not debugging, we default to ifNotPresent.

Here's [another explanation](https://kukulinski.com/10-most-common-reasons-kubernetes-deployments-fail-part-2/#10containerimagenotupdating).

How did I test this?

* Step 1: I've set imagePullPolicy to "Always" in config.yaml.

* Step 2: Upload initial image, it adds a line to `jupyterhub_config.py`.
```bash
$ kubectl exec hub-deployment-2875592925-659z1  -- cat /srv/jupyterhub_config.py | grep "hi there"
# hi there!
```

* Step 3: Update this line to say "hi there 2", rebuild image, upgrade.
```bash
helm upgrade kubehub ~/work/github/helm-chart-fork/jupyterhub/ -f ./config.yaml --debug

$ kubectl exec hub-deployment-3530821855-4qw0k  -- cat /srv/jupyterhub_config.py | grep "hi there"
# hi there 2!
```

* Step 4: Remove “Always” from config.yaml. We're now defaulting to "IfNotPresent"

```bash
$ helm upgrade kubehub ~/work/github/helm-chart-fork/jupyterhub/ -f ./config.yaml --debug

$ kubectl exec hub-deployment-568529703-9jc03  -- cat /srv/jupyterhub_config.py | grep "hi there"
# hi there!
```

So the default works too.

I don't know why when using "IfNotPresent" it defaults to version 1 and not version 2, but it's not a problem.
