### PR TITLE
Custom authenticator support

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -1,4 +1,3 @@
-import importlib
 import os
 import sys
 import yaml

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -184,19 +184,11 @@ elif auth_type == 'custom':
     # following Dockerifle:
     #   FROM jupyterhub/k8s-hub:v0.4
     #   RUN pip3 install myauthenticator
-    full_class_name = get_config('auth.custom.class_name')
+    full_class_name = get_config('auth.custom.class-name')
     c.JupyterHub.authenticator_class = full_class_name
-
-    (module, class_name) = full_class_name.split('.')
-    the_module = importlib.import_module(module)
-    klass=getattr(the_module, class_name)
-
-    class_params = get_config('auth.custom.params')
-    for (class_var_name, class_var_value) in class_params.items():
-      if hasattr(klass, class_var_name):
-        setattr(klass, class_var_name, class_var_value)
-      else:
-        raise ValueError("Attribute doesn't exist: %r" % class_var_name)
+    auth_class_name = full_class_name.rsplit('.', 1)[-1]
+    auth_config = c[auth_class_name]
+    auth_config.update(get_config('auth.custom.traitlets') or {})
 else:
     raise ValueError("Unhandled auth type: %r" % auth_type)
 

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -1,6 +1,7 @@
-import yaml
+import importlib
 import os
 import sys
+import yaml
 from tornado.httpclient import AsyncHTTPClient
 
 def get_config(key, default=None):
@@ -177,6 +178,25 @@ elif auth_type == 'dummy':
     c.DummyAuthenticator.password = get_config('auth.dummy.password', None)
 elif auth_type == 'tmp':
     c.JupyterHub.authenticator_class = 'tmpauthenticator.TmpAuthenticator'
+elif auth_type == 'custom':
+    # full_class_name looks like "myauthenticator.MyAuthenticator".
+    # To create a docker image with this class availabe, you can just have the
+    # following Dockerifle:
+    #   FROM jupyterhub/k8s-hub:v0.4
+    #   RUN pip3 install myauthenticator
+    full_class_name = get_config('auth.custom.class_name')
+    c.JupyterHub.authenticator_class = full_class_name
+
+    (module, class_name) = full_class_name.split('.')
+    the_module = importlib.import_module(module)
+    klass=getattr(the_module, class_name)
+
+    class_params = get_config('auth.custom.params')
+    for (class_var_name, class_var_value) in class_params.items():
+      if hasattr(klass, class_var_name):
+        setattr(klass, class_var_name, class_var_value)
+      else:
+        raise ValueError("Attribute doesn't exist: %r" % class_var_name)
 else:
     raise ValueError("Unhandled auth type: %r" % auth_type)
 

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -187,7 +187,7 @@ elif auth_type == 'custom':
     c.JupyterHub.authenticator_class = full_class_name
     auth_class_name = full_class_name.rsplit('.', 1)[-1]
     auth_config = c[auth_class_name]
-    auth_config.update(get_config('auth.custom.traitlets') or {})
+    auth_config.update(get_config('auth.custom.config') or {})
 else:
     raise ValueError("Unhandled auth type: %r" % auth_type)
 

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -38,6 +38,11 @@ data:
   {{- end }}
   {{- end }}
 
+  {{ if eq .Values.auth.type "custom" -}}
+  auth.custom.class_name: {{ .Values.auth.custom.className | quote }}
+  auth.custom.params: {{ toJson .Values.auth.custom.params | quote }}
+  {{- end }}
+
   {{ if .Values.singleuser.lifecycleHooks -}}
   singleuser.lifecycle-hooks: {{ toJson .Values.singleuser.lifecycleHooks | quote }}
   {{- end }}

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -40,7 +40,7 @@ data:
 
   {{ if eq .Values.auth.type "custom" -}}
   auth.custom.class-name: {{ .Values.auth.custom.className | quote }}
-  auth.custom.traitlets: {{ toJson .Values.auth.custom.traitlets | quote }}
+  auth.custom.config : {{ toJson .Values.auth.custom.config | quote }}
   {{- end }}
 
   {{ if .Values.singleuser.lifecycleHooks -}}

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -39,8 +39,8 @@ data:
   {{- end }}
 
   {{ if eq .Values.auth.type "custom" -}}
-  auth.custom.class_name: {{ .Values.auth.custom.className | quote }}
-  auth.custom.params: {{ toJson .Values.auth.custom.params | quote }}
+  auth.custom.class-name: {{ .Values.auth.custom.className | quote }}
+  auth.custom.traitlets: {{ toJson .Values.auth.custom.traitlets | quote }}
   {{- end }}
 
   {{ if .Values.singleuser.lifecycleHooks -}}


### PR DESCRIPTION
Without modifying jupyterhub_config.py

Example: in config.yaml, add this:

```bash
auth:
  type: "custom"
  custom:
    className: "hashauthenticator.HashAuthenticator"
    params:
      secret_key: "834e6cace4747e966c002737191619f583be814557d3f11e358232a9a28dfa7d"
```


I have verified that this works by doing the following:

* Step 1: I copied the hub image and built my own version, using the code from this branch.

* Step 2: I made a new image derived from the one built in step 1. Looks like this:

```bash
$ cat ./docker-images/helm-hub-derived/Dockerfile 
FROM gcr.io/mooc-hub/helm-hub:43e48f9-debug
RUN pip3 install --no-cache-dir jupyterhub-hashauthenticator
```

* Step 3: I redeployed and confirmed that I use the specified authenticator.

```bash
$ ./hub-api.sh GET info
{
    "spawner": {
        "version": "unknown",
        "class": "kubespawner.spawner.KubeSpawner"
    },
    "version": "0.7.2",
    "sys_executable": "/usr/bin/python3",
    "python": "3.5.3 (default, Jan 19 2017, 14:11:04) \n[GCC 6.3.0 20170118]",
    "authenticator": {
        "version": "unknown",
        "class": "hashauthenticator.hashauthenticator.HashAuthenticator"
    }
}
```

* Step 4: I logged in, it worked.

* Step 5: Hub logs look clean:

```bash
$ kubectl logs hub-deployment-971314756-7j1h3
[I 2017-07-18 18:38:12.791 JupyterHub app:720] Loading cookie_secret from env[JPY_COOKIE_SECRET]
[I 2017-07-18 18:38:12.869 JupyterHub app:892] Not using whitelist. Any authenticated user will be allowed.
[I 2017-07-18 18:38:12.930 JupyterHub app:1089] petko still running
[I 2017-07-18 18:38:12.945 JupyterHub app:1453] Hub API listening on http://0.0.0.0:8081/hub/
[I 2017-07-18 18:38:12.952 JupyterHub app:1143] Proxy already running at: http://10.39.252.21:80/
[I 2017-07-18 18:38:12.955 JupyterHub service:220] Starting service 'cull-idle': ['/usr/bin/python3', '/usr/local/bin/cull_idle_servers.py', '--timeout=3600', '--cull_every=600']
[I 2017-07-18 18:38:12.957 JupyterHub service:90] Spawning /usr/bin/python3 /usr/local/bin/cull_idle_servers.py --timeout=3600 --cull_every=600
[I 2017-07-18 18:38:12.960 JupyterHub app:1485] JupyterHub is now running at http://10.39.252.21:80/
[I 2017-07-18 18:38:12.962 JupyterHub orm:188] Adding user petko to proxy /user/petko => http://10.36.0.32:8888
[I 2017-07-18 18:38:13.168 JupyterHub log:100] 200 GET /hub/api/users (cull-idle@127.0.0.1) 14.58ms
[I 2017-07-18 18:38:45.727 JupyterHub log:100] 302 GET / (@10.36.1.1) 3.03ms
```