### PR TITLE
Allow setting up TLS manually

### DIFF
--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
     - secretName: kubelego-tls-proxy-{{ .Release.Name }}
       hosts:
         - {{ .Values.ingress.host }}
-{{- else if eq .Values.ingres.https.type "manual" }}
+{{- else if eq .Values.ingress.https.type "manual" }}
   tls:
     - secretName: manual-tls-proxy-{{ .Release.Name }}
       hosts:

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -21,9 +21,15 @@ spec:
               serviceName: proxy-public
               servicePort: 80
       host: {{ .Values.ingress.host }}
-{{- if and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego") }}
+{{- if .Values.ingress.https.enabled }}
+{{- if eq .Values.ingress.https.type "kube-lego" }}
   tls:
     - secretName: kubelego-tls-proxy-{{ .Release.Name }}
+      hosts:
+        - {{ .Values.ingress.host }}
+{{- else if eq .Values.ingres.https.type "manual" }}
+  tls:
+    - secretName: manual-tls-proxy-{{ .Release.Name }}
       hosts:
         - {{ .Values.ingress.host }}
 {{- end }}


### PR DESCRIPTION
We don't want to keep TLS keys in config.yaml - so user will
have to manually create & rotate TLS secrets.