### PR TITLE
add storage class name option to the sqlite pvc

### DIFF
--- a/jupyterhub/templates/hub/pvc.yaml
+++ b/jupyterhub/templates/hub/pvc.yaml
@@ -14,6 +14,9 @@ spec:
   selector:
 {{ toYaml .Values.hub.db.pvc.selector | indent 4 }}
   {{- end }}
+  {{ if .Values.hub.db.pvc.storageClass -}}
+  storageClassName: {{ .Values.hub.db.pvc.storageClass | quote }}
+  {{- end }}
   accessModes:
     {{- range $mode := .Values.hub.db.pvc.accessModes }}
     - {{ $mode }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -17,6 +17,7 @@ hub:
         - ReadWriteOnce
       storage: 1Gi
       subPath: null
+      storageClassName: null
     url: null
   labels: null
   extraConfig: null


### PR DESCRIPTION
Currently, there isn't a way to set the storageClassName on this helm-chart so if you don't have a default storageclass, the pvc will never be bound. We have several storage classes and we want to define a specific one for the sqlite-pvc.

@tpetr
@yuvipanda 

