### PR TITLE
only set cookie secret env if specified

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -54,11 +54,13 @@ spec:
         # change this
         - name: SINGLEUSER_IMAGE
           value:  "{{ .Values.singleuser.image.name }}:{{ .Values.singleuser.image.tag }}"
+        {{ if ne .Values.hub.cookieSecret null }}
         - name: JPY_COOKIE_SECRET
           valueFrom:
             secretKeyRef:
               name: hub-secret
               key: hub.cookie-secret
+        {{- end }}
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -54,7 +54,7 @@ spec:
         # change this
         - name: SINGLEUSER_IMAGE
           value:  "{{ .Values.singleuser.image.name }}:{{ .Values.singleuser.image.tag }}"
-        {{ if ne .Values.hub.cookieSecret null }}
+        {{ if .Values.hub.cookieSecret }}
         - name: JPY_COOKIE_SECRET
           valueFrom:
             secretKeyRef:

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -5,6 +5,6 @@ metadata:
 type: Opaque
 data:
   proxy.token: {{ .Values.proxy.secretToken | b64enc | quote }}
-  {{ if ne .Values.hub.cookieSecret null }}
+  {{ if .Values.hub.cookieSecret }}
   hub.cookie-secret: {{ .Values.hub.cookieSecret | b64enc | quote }}
   {{- end }}

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -5,4 +5,6 @@ metadata:
 type: Opaque
 data:
   proxy.token: {{ .Values.proxy.secretToken | b64enc | quote }}
+  {{ if ne .Values.hub.cookieSecret null }}
   hub.cookie-secret: {{ .Values.hub.cookieSecret | b64enc | quote }}
+  {{- end }}


### PR DESCRIPTION
default behavior when cookie secret is null is already fine because it will create jupyterhub_cookie_secret file in the db volume directory

cookieSecret is only necessary if there isn’t a volume mounted for the hub (i.e. sqlite db)

Even if not set, the only consequence is that rebooting the hub logs out users.

The non-sqlite case is not validated, however. It would probably be nice to fail with an informative error if the db is external and cookieSecret is not set, but I don't know how to do that.