### PR TITLE
remove deprecated --no-ssl arg from hub image

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -49,4 +49,4 @@ EXPOSE 8081
 
 USER ${NB_USER}
 
-CMD jupyterhub --config /srv/jupyterhub_config.py --no-ssl
+CMD jupyterhub --config /srv/jupyterhub_config.py


### PR DESCRIPTION
it doesn't do anything