### PR TITLE
enable jupyterhub_config.py and configmap.yaml for handling gitlab auth

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -132,6 +132,11 @@ elif auth_type == 'github':
     c.GitHubOAuthenticator.oauth_callback_url = get_config('auth.github.callback-url')
     c.GitHubOAuthenticator.client_id = get_config('auth.github.client-id')
     c.GitHubOAuthenticator.client_secret = get_config('auth.github.client-secret')
+elif auth_type == 'gitlab':
+    c.JupyterHub.authenticator_class = 'oauthenticator.gitlab.GitLabOAuthenticator'
+    c.GitLabOAuthenticator.oauth_callback_url = get_config('auth.gitlab.callback-url')
+    c.GitLabOAuthenticator.client_id = get_config('auth.gitlab.client-id')
+    c.GitLabOAuthenticator.client_secret = get_config('auth.gitlab.client-secret')
 elif auth_type == 'mediawiki':
     c.JupyterHub.authenticator_class = 'oauthenticator.mediawiki.MWOAuthenticator'
     c.MWOAuthenticator.client_id = get_config('auth.mediawiki.client-id')

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -25,6 +25,11 @@ data:
   auth.github.client-secret: {{.Values.auth.github.clientSecret | quote}}
   auth.github.callback-url: {{.Values.auth.github.callbackUrl | quote}}
   {{- end }}
+  {{ if eq .Values.auth.type "gitlab" -}}
+  auth.gitlab.client-id: {{.Values.auth.gitlab.clientId | quote}}
+  auth.gitlab.client-secret: {{.Values.auth.gitlab.clientSecret | quote}}
+  auth.gitlab.callback-url: {{.Values.auth.gitlab.callbackUrl | quote}}
+  {{- end }}
   {{ if eq .Values.auth.type "mediawiki" -}}
   auth.mediawiki.client-id: {{.Values.auth.mediawiki.clientId | quote}}
   auth.mediawiki.client-secret: {{.Values.auth.mediawiki.clientSecret | quote}}


### PR DESCRIPTION
@yuvipanda ... added in those items to handle authentication with gitlab in the helm-chart.