### PR TITLE
add nullauthenticator

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -29,6 +29,7 @@ RUN pip3 install --no-cache-dir \
          statsd==3.2.1 \
          jupyterhub-dummyauthenticator==0.3.1 \
          jupyterhub-tmpauthenticator==0.4 \
+         nullauthenticator==1.0 \
          pymysql==0.7.11 \
          psycopg2==2.7.1 \
          pycurl==7.43.0 \


### PR DESCRIPTION
I'm working on binderhub creating things via the API, eliminating use of tmpauthenticator.

Initially, I thought this needed jupyterhub 0.8, but now I believe we can do all of this in Binder with 0.7 by launching jupyter-notebook instead of jupyterhub-singleuser.