### PR TITLE
[WIP binder] launch with JupyterHub API

### DIFF
--- a/binderhub/templates/deployment.yaml
+++ b/binderhub/templates/deployment.yaml
@@ -78,6 +78,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: JUPYTERHUB_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hub-secret
+              key: "services.token-binder"
         ports:
           - containerPort: 8585
             name: binder

--- a/binderhub/values.yaml
+++ b/binderhub/values.yaml
@@ -28,44 +28,42 @@ hub:
 jupyterhub:
   hub:
     extraConfig: |
-      import json
-      import urllib
-      from tmpauthenticator import TmpAuthenticator
+      # disable login (users created exclusively via API)
+      c.JupyterHub.authenticator_class = 'nullauthenticator.NullAuthenticator'
+
+      # image & token are set via spawn options
       from kubespawner import KubeSpawner
-      from jupyterhub.utils import url_path_join
-      class DynamicImageAuth(TmpAuthenticator):
-          def process_user(self, user, handler):
-              # We take all the url params and put them into a `url_options` field
-              # Not using `user_options` since that seems to be cleared by JupyterHub.
-              arguments = { k: handler.get_argument(k) for k in handler.request.arguments }
-              user.spawner.url_options = arguments
-              return user
 
-          def pre_spawn_start(self, user, spawner):
-              # Support for each runtime parameter is set up here!
-              # FIXME: Make sure we only run authorized images!
-              spawner.singleuser_image_spec = spawner.url_options['image']
+      class BinderSpawner(KubeSpawner):
+        def get_args(self):
+            return [
+                '--ip=0.0.0.0',
+                '--port=%i' % self.port,
+                '--NotebookApp.base_url=%s' % self.server.base_url,
+                '--NotebookApp.token=%s' % self.user_options['token'],
+            ] + self.args
 
-              # Detect if we're pointing to a particular file!
-              # FIXME:
-              filepath = spawner.url_options.get('filepath', None)
-              if filepath:
-                  parts = urllib.parse.urlparse(filepath)
-                  if parts.path.endswith('.ipynb'):
-                      parts = parts._replace(path=url_path_join('/notebooks', parts.path))
-                  else:
-                      parts = parts._replace(path=url_path_join('/edit', parts.path))
-                  spawner.default_url = urllib.parse.urlunparse(parts)
+        def start(self):
+            if 'token' not in self.user_options:
+              raise web.HTTPError(400, "token required")
+            if 'image' not in self.user_options:
+              raise web.HTTPError(400, "image required")
 
+            self.singleuser_image_spec = self.user_options['image']
+            return super().start()
 
-      c.JupyterHub.authenticator_class = DynamicImageAuth
-      c.DynamicImageAuth.force_new_server = True
-      c.KubeSpawner.args.append('--NotebookApp.disable_check_xsrf=True')
-      c.KubeSpawner.args.append('--NotebookApp.allow_origin="*"')
-      # FIXME: Make this more secure?
-      c.KubeSpawner.args.append('--NotebookApp.tornado_settings={}'.format(json.dumps({'headers': {'Content-Security-Policy': ' '}})))
+      c.JupyterHub.spawner_class = BinderSpawner
+
+      # add binder API token
+      c.JupyterHub.services.append({
+          'name': 'binder',
+          'admin': True,
+          'api_token': "HARDCODED",
+      })
 
   singleuser:
+    # start jupyter notebook
+    cmd: jupyter-notebook
     storage:
       type: none
     memory:

--- a/binderhub/values.yaml
+++ b/binderhub/values.yaml
@@ -7,7 +7,7 @@ image:
   name: jupyterhub/k8s-binderhub
   tag: vbd57123
 
-repo2dockerImage: jupyter/repo2docker:v0.2.10
+repo2dockerImage: jupyter/repo2docker:v0.4.1
 
 googleAnalyticsCode: null
 

--- a/binderhub/values.yaml
+++ b/binderhub/values.yaml
@@ -5,7 +5,7 @@ resources:
 
 image:
   name: jupyterhub/k8s-binderhub
-  tag: vbd57123
+  tag: v268761c
 
 repo2dockerImage: jupyter/repo2docker:v0.4.1
 
@@ -54,12 +54,10 @@ jupyterhub:
 
       c.JupyterHub.spawner_class = BinderSpawner
 
-      # add binder API token
-      c.JupyterHub.services.append({
-          'name': 'binder',
-          'admin': True,
-          'api_token': "HARDCODED",
-      })
+    services:
+      binder:
+        admin: true
+        apiToken: null
 
   singleuser:
     # start jupyter notebook

--- a/images/binderhub/Dockerfile
+++ b/images/binderhub/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.04
+FROM ubuntu:17.10
 
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends \

--- a/images/binderhub/Dockerfile
+++ b/images/binderhub/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && \
             python3-pip && \
     apt-get clean
 
-RUN pip3 install --no-cache-dir git+https://github.com/jupyterhub/binderhub.git@1d6f130b3b
+# FIXME: temporary ref pending binderhub#110
+RUN pip3 install --no-cache-dir git+https://github.com/minrk/binderhub.git@d6d12fa
 ADD binderhub_config.py /etc
 
 WORKDIR /etc

--- a/images/binderhub/binderhub_config.py
+++ b/images/binderhub/binderhub_config.py
@@ -26,6 +26,7 @@ c.BinderHub.build_namespace = os.environ['BUILD_NAMESPACE']
 c.BinderHub.use_registry = get_config('binder.use-registry', True)
 
 c.BinderHub.builder_image_spec = get_config('binder.repo2docker-image')
-c.BinderHub.hub_login_url = get_config('binder.hub-url') + '/hub/tmplogin'
+c.BinderHub.hub_url = get_config('binder.hub-url')
+c.BinderHub.hub_api_token = os.environ['JUPYTERHUB_API_TOKEN']
 
 c.BinderHub.google_analytics_code = get_config('binder.google-analytics-code', None)

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -193,22 +193,30 @@ c.JupyterHub.admin_access = get_config('admin.access')
 
 c.Authenticator.admin_users = get_config('admin.users', [])
 
+c.JupyterHub.services = []
 
 if get_config('cull.enabled', False):
     cull_timeout = get_config('cull.timeout')
     cull_every = get_config('cull.every')
-    c.JupyterHub.services = [
-        {
-            'name': 'cull-idle',
-            'admin': True,
-            'command': [
-                '/usr/bin/python3',
-                '/usr/local/bin/cull_idle_servers.py',
-                '--timeout=%s' % cull_timeout,
-                '--cull_every=%s' % cull_every
-            ]
-        }
-    ]
+    c.JupyterHub.services.append({
+        'name': 'cull-idle',
+        'admin': True,
+        'command': [
+            '/usr/bin/python3',
+            '/usr/local/bin/cull_idle_servers.py',
+            '--timeout=%s' % cull_timeout,
+            '--cull_every=%s' % cull_every
+        ]
+    })
+
+for name, service in get_config('hub.services', {}).items():
+    api_token = os.getenv('SERVICE_TOKEN_%s' % name.upper(), None)
+    # jupyterhub.services is a list of dicts, but
+    # in the helm chart it is a dict of dicts for easier merged-config
+    service.setdefault('name', name)
+    if api_token is not None:
+        service['api_token'] = api_token
+    c.JupyterHub.services.append(service)
 
 c.JupyterHub.base_url = get_config('hub.base_url')
 

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -52,6 +52,18 @@ data:
   {{- end }}
 
   hub.concurrent-spawn-limit: {{ .Values.hub.concurrentSpawnLimit | quote }}
+  {{ if .Values.hub.services -}}
+  hub.services: |
+    # include hub.services *except* api_tokens
+    {{ range $name, $service := .Values.hub.services -}}
+    {{$name}}:
+      {{ range $key, $value := $service -}}
+      {{ if ne $key "apiToken" -}}
+      {{$key}}: {{ $value }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
   {{ if .Values.hub.extraConfig -}}
   hub.extra-config.py: |
 {{ .Values.hub.extraConfig | indent 4 }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -68,6 +68,15 @@ spec:
             secretKeyRef:
               name: hub-secret
               key: proxy.token
+        {{ range $key, $value := .Values.hub.services -}}
+        {{ if $value.apiToken }}
+        - name: "SERVICE_TOKEN_{{$key | upper}}"
+          valueFrom:
+            secretKeyRef:
+              name: hub-secret
+              key: "services.token-{{$key}}"
+        {{ end -}}
+        {{ end -}}
         {{ range $key, $value := .Values.hub.extraEnv -}}
         - name: {{ $key | quote }}
           value: {{ $value | quote }}

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -6,3 +6,8 @@ type: Opaque
 data:
   proxy.token: {{ .Values.proxy.secretToken | b64enc | quote }}
   hub.cookie-secret: {{ .Values.hub.cookieSecret | b64enc | quote }}
+  {{ range $key, $value := .Values.hub.services -}}
+  {{ if $value.apiToken }}
+  services.token-{{$key}}: {{ $value.apiToken | b64enc | quote }}
+  {{ end }}
+  {{ end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -31,6 +31,7 @@ hub:
     requests:
       cpu: 0.2
       memory: 512Mi
+  services: {}
   imagePullPolicy: IfNotPresent
 
 proxy:

--- a/minikube-binder.yaml
+++ b/minikube-binder.yaml
@@ -8,9 +8,12 @@ service:
 
 jupyterhub:
   hub:
-      cookieSecret: 1470700e01f77171c2c67b12130c25081dfbdf2697af8c2f2bd05621b31100bf
-      db:
-        type: sqlite-memory
+    cookieSecret: 1470700e01f77171c2c67b12130c25081dfbdf2697af8c2f2bd05621b31100bf
+    db:
+      type: sqlite-memory
+    services:
+      binder:
+        apiToken: 0c18e3dcb7c55b8c7740f1d7ee6977510ce3cb22221669278ee03f3c2259ab6b
 
   proxy:
     secretToken: f89ddee5ba10f2268fcefcd4e353235c255493095cd65addf29ebebf8df86255

--- a/minikube-binder.yaml
+++ b/minikube-binder.yaml
@@ -1,3 +1,8 @@
+resources:
+  requests:
+    cpu: 0.2
+    memory: 100Mi
+
 hub:
   url: http://192.168.99.100:30949
 
@@ -8,6 +13,10 @@ service:
 
 jupyterhub:
   hub:
+    resources:
+      requests:
+        cpu: 0.2
+        memory: 100Mi
     cookieSecret: 1470700e01f77171c2c67b12130c25081dfbdf2697af8c2f2bd05621b31100bf
     db:
       type: sqlite-memory


### PR DESCRIPTION
This is the counterpart to https://github.com/jupyterhub/binderhub/pull/110

Missing piece:

- [x] add binder.hubToken via secret to both binder and hub

What's the best way to get something binder-specific into the Hub container via a secret? Can the binderhub chart *extend* the jupyterhub chart?