### PR TITLE
manually fix release dates on old jupyterhub releases

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1515,7 +1515,7 @@ entries:
     - https://jupyterhub.github.io/helm-chart/jupyterhub-v0.5.0-0930092.tgz
     version: v0.5.0-0930092
   - apiVersion: v1
-    created: 2017-08-06T00:26:58Z
+    created: 2017-06-27T22:11:03Z
     description: Multi-user Jupyter installation
     digest: 0f5f5cf279c20147d594b48369862ef8886613b15f39254af441dd03018c1540
     name: jupyterhub
@@ -1723,7 +1723,7 @@ entries:
     - https://jupyterhub.github.io/helm-chart/jupyterhub-v0.4.0-0774732.tgz
     version: v0.4.0-0774732
   - apiVersion: v1
-    created: 2017-08-12T20:03:26Z
+    created: 2017-05-19T23:50:56Z
     description: Multi-user Jupyter installation
     digest: 37c247d77ecd43208fd87e8e04c44de3d4ffcfee558d38bddfde9392db2e4b82
     name: jupyterhub
@@ -1731,7 +1731,7 @@ entries:
     - https://jupyterhub.github.io/helm-chart/jupyterhub-v0.3.1.tgz
     version: v0.3.1
   - apiVersion: v1
-    created: 2017-08-12T20:03:26Z
+    created: 2017-05-13T20:32:59Z
     description: Multi-user Jupyter installation
     digest: 46fbb1f19bc3407175b21e855dfab99bb087e8697998f4d83b541cfd610f3d4b
     name: jupyterhub


### PR DESCRIPTION
0.3-0.4 release dates from git were inaccurate due to a migration in August.

Looked up the dates of the zero-to-jupyterhub tags and entered them manually here.

Dates for all releases will no longer be recomputed, so this should stick.