### PR TITLE
Update 0.8 to 0.8.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ in the hub pod, see the associated `Dockerfile` or `requirements.txt`.
 
 | Helm Chart v. | JupyterHub v. | Req. Kubernetes v. | Req. Helm v. | Associated files
 | ------ | ------ | ------ | ------- | ------ |
-| 0.8.0  | 0.9.4  | 1.11+  | 2.11.0+ | [0.8.0](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/0.8.0/images/hub) |
+| 0.8.1  | 0.9.5  | 1.11+  | 2.11.0+ | [0.8.1](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/0.8.1/images/hub) |
 | 0.7.0  | 0.9.2  | 1.8+   | 2.9.0+  | [0.7.0](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/0.7.0/images/hub) |
 | v0.6   | 0.8.1  | ?      | ?       | [v0.6](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/v0.6/images/hub) |
 | v0.5   | 0.8.1  | ?      | ?       | [v0.5](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/v0.5/images/hub) |


### PR DESCRIPTION
To address https://blog.jupyter.org/open-redirect-vulnerability-in-jupyter-jupyterhub-adf43583f1e4.