### PR TITLE
Rewrite index.md

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,9 @@
 title: JupyterHub and BinderHub Helm charts for Kubernetes
 description: This repository stores Helm chart tarballs for BinderHub and JupyterHub.  Actual development of the Helm charts takes place in the BinderHub and Zero to JupyterHub repos.
 
+theme: jekyll-theme-minimal
+
+repository: jupyterhub/zero-to-jupyterhub
+
+stablecharts:
+  - jupyterhub

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ description: This repository stores Helm chart tarballs for BinderHub and Jupyte
 
 theme: jekyll-theme-minimal
 
-repository: jupyterhub/zero-to-jupyterhub
+repository: jupyterhub/zero-to-jupyterhub-k8s
 
 stablecharts:
   - jupyterhub

--- a/index.md
+++ b/index.md
@@ -1,86 +1,39 @@
-<html>
-<body>
+## See installation instructions for:
 
-<p>See installation instructions for:</p>
-
-<ul>
-<li><a href="https://zero-to-jupyterhub.readthedocs.io">JupyterHub</a></li>
-<li><a href="https://binderhub.readthedocs.io">BinderHub</a></li>
-</ul>
+- [JupyterHub](https://zero-to-jupyterhub.readthedocs.io)
+- [BinderHub](https://binderhub.readthedocs.io)
 
 Jump to:
+{% for chartmap in site.data.index.entries -%}
+- [Development Releases: {{ chartmap[0] }}](#development-releases-{{ chartmap[0] | slugify }})
+{% endfor %}
 
-<ul>
-<li><a href="#development-releases-jupyterhub">Development Releases: JupyterHub</a></li>
-<li><a href="#development-releases-binderhub">Development Releases: BinderHub</a></li>
-</ul>
 
-<h2>Stable releases</h2>
-{% assign jupyterhub = site.data.index.entries.jupyterhub | sort: 'created' | reverse %}
-{% assign binderhub = site.data.index.entries.binderhub | sort: 'created' | reverse %}
-{% assign all_charts = jupyterhub | concat: binderhub %}
-<table>
-  <tr>
-    <th>release</th>
-    <th>date</th>
-  </tr>
-  {% for chart in all_charts %}
-    {% unless chart.version contains "-"%}
-    <tr>
-      <td>
-      <a href="{{ chart.urls[0] }}">
-          {{ chart.name }}-{{ chart.version | remove_first: "v" }}
-      </a>
-      </td>
-      <td>
-      <span class='date'>{{ chart.created | date_to_rfc822 }}</span>
-      </td>
-    </tr>
-    {% endunless %}
-  {% endfor %}
-</table>
+## Stable releases
 
-<h2>Development releases: JupyterHub</h2>
-<table>
-  <tr>
-    <th>release</th>
-    <th>date</th>
-  </tr>
-  {% for chart in jupyterhub %}
-    <tr>
-      <td>
-      {% unless chart.version contains "-" %}<b>{% endunless %}
-      <a href="{{ chart.urls[0] }}">
-          {{ chart.name }}-{{ chart.version | remove_first: "v" }}
-      </a>
-      {% unless chart.version contains "-" %}</b>{% endunless %}
-      </td>
-      <td>
-      <span class='date'>{{ chart.created | date_to_rfc822 }}</span>
-      </td>
-    </tr>
+{% for chartmap in site.data.index.entries %}
+  {% if site.stablecharts contains chartmap[0] %}
+### {{ chartmap[0] }}
+
+| Release | Date | Application version |
+|---------|------|---------------------|
+  {%- assign sortedcharts = chartmap[1] | sort: 'created' | reverse -%}
+    {%- for chart in sortedcharts -%}
+      {%- unless chart.version contains "-" %}
+| [{{ chart.name }}-{{ chart.version | remove_first: "v" }}]({{ chart.urls[0] }}) | {{ chart.created | date_to_rfc822 }} | {{ chart.appVersion }} |
+      {%- endunless -%}
+    {% endfor %}
+  {% endif %}
+{% endfor %}
+
+
+{% for chartmap in site.data.index.entries %}
+### Development releases: {{ chartmap[0] }}
+
+| Release | Date | Application version |
+|---------|------|---------------------|
+  {% assign sortedcharts = chartmap[1] | sort: 'created' | reverse -%}
+  {% for chart in sortedcharts -%}
+| [{{ chart.name }}-{{ chart.version | remove_first: "v" }}]({{ chart.urls[0] }}) | {{ chart.created | date_to_rfc822 }} | {{ chart.appVersion }} |
   {% endfor %}
-</table>
-<h2>Development releases: BinderHub</h2>
-<table>
-  <tr>
-    <th>release</th>
-    <th>date</th>
-  </tr>
-  {% for chart in binderhub %}
-    <tr>
-      <td>
-      {% unless chart.version contains "-" %}<b>{% endunless %}
-      <a href="{{ chart.urls[0] }}">
-          {{ chart.name }}-{{ chart.version | remove_first: "v" }}
-      </a>
-      {% unless chart.version contains "-" %}</b>{% endunless %}
-      </td>
-      <td>
-      <span class='date'>{{ chart.created | date_to_rfc822 }}</span>
-      </td>
-    </tr>
-  {% endfor %}
-</table>
-</body>
-</html>
+{% endfor %}


### PR DESCRIPTION
- Remove invalid mix of HTML and markdown (View source on https://jupyterhub.github.io/helm-chart/ and you'll see), replaced with Jekyll templated markdown only
- Include appVersion in table (Closes https://github.com/jupyterhub/helm-chart/issues/106)
- Add a GH pages theme instead of the default one which is a bit sparse- though I'm happy to revert this change.

Preview available at https://www.manicstreetpreacher.co.uk/helm-chart/

In addition we've considered using this repo for other Helm charts (can't remember which repo/issue this came up on). With this change all charts should automatically appear under development without changes to this template. To add a new chart as stable just requires adding it to the list in `_config.yml`