### PR TITLE
artifacts hub: verify ownership / don't list dev versions

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,16 @@
+# Artifact Hub (https://artifacthub.io) repository metadata file
+# ref: https://github.com/artifacthub/hub/blob/master/docs/repositories.md#helm-charts-repositories
+#
+repositoryID: 80d1725c-b26d-4567-ba5c-0c60643c92b2
+owners: # (optional, used to claim repository ownership)
+  - name: Erik Sundell
+    email: erik@sundellopensource.se
+  - name: Simon Li
+    email: orpheus+devel@gmail.com
+ignore:
+  - name: jupyterhub
+    version: &stable-or-alpha-beta '^((?!\d+.\d+.\d+$|-alpha.\d+$|-beta.\d+$).)*$'
+  - name: binderhub
+    version: *stable-or-alpha-beta
+  - name: pebble
+    version: *stable-or-alpha-beta


### PR DESCRIPTION
In https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1820 I tried adding this file to z2jh repo before but what matters is the actual content served by the helm chart repo webserver: gh-pages content of this repo.

Outcomes:
- The JupyterHub org on artifactshub.io becomes the verified publisher of the jupyterhub helm chart repo on artifactshub.io
- The published versions become restricted to tagged releases like 1.2.3 and 1.2.3-alpha.x and 1.2.3-beta.x but excludes all other versions.

Future:
- More members of the jupyterhub team create accounts on https://artifacthub.io/ so I can invite them as members of the JupyterHub org I've created there.