### PR TITLE
Let artifacthub.io publish dev versions also temporarily

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -31,5 +31,5 @@ ignore:
   #
   - name: binderhub
   - name: jupyterhub
-    version: "-"
+    # version: "-"
   - name: pebble


### PR DESCRIPTION
I want to trial use of Chart.yaml annotations in dev-releases before we cut a proper release, so I want to enable listing of dev-releases for a while.