### PR TITLE
limit listed development charts to one year

### DIFF
--- a/index.md
+++ b/index.md
@@ -26,6 +26,10 @@ Jump to:
   {%- endif %}
 {% endfor %}
 
+{%- comment %}
+Limit advertised development releases to those published in the last year
+{%- endcomment %}
+{%- assign year_ago = 'now' | date: "%s" | minus: 31536000 %}
 
 {% for chartmap in site.data.index.entries %}
 ### Development releases: {{ chartmap[0] }}
@@ -34,6 +38,9 @@ Jump to:
 |---------|------|---------------------|
   {%- assign sortedcharts = chartmap[1] | sort: 'created' | reverse %}
   {%- for chart in sortedcharts %}
+    {%- assign created_timestamp = chart.created | date: "%s" | plus: 0 %}
+    {%- if created_timestamp >= year_ago %}
 | [{{ chart.version }}]({{ chart.urls[0] }}) | {{ chart.created | date_to_long_string }} | {{ chart.appVersion }} |
+    {%- endif %}
   {%- endfor %}
 {% endfor %}

--- a/index.md
+++ b/index.md
@@ -34,6 +34,8 @@ Limit advertised development releases to those published in the last year
 {% for chartmap in site.data.index.entries %}
 ### Development releases: {{ chartmap[0] }}
 
+Development releases older than one year isn't listed below.
+
 | Version | Date | App. version |
 |---------|------|---------------------|
   {%- assign sortedcharts = chartmap[1] | sort: 'created' | reverse %}


### PR DESCRIPTION
- only development releases list, doesn't affect stable releases
- doesn't affect actual chart repository for `helm install`, just the for-humans HTML view

helps the page be navigable without getting super long